### PR TITLE
Launch apps identified by ros distro flavours

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ subprojects {
         exclude "META-INF/NOTICE.txt"
       }
     }
+
   }
 }
 

--- a/common_tools/build.gradle
+++ b/common_tools/build.gradle
@@ -41,7 +41,7 @@ android {
     minSdkVersion 15
     targetSdkVersion 15
     versionCode 1
-    versionName "1.0"
+    versionName "1.0.1"
   }
 
 }

--- a/common_tools/src/main/java/com/github/rosjava/android_remocons/common_tools/rocon/AppLauncher.java
+++ b/common_tools/src/main/java/com/github/rosjava/android_remocons/common_tools/rocon/AppLauncher.java
@@ -218,7 +218,7 @@ public class AppLauncher {
         Result result  = Result.OTHER_ERROR;
         String launchablePkgName = "";
         PackageManager manager = parent.getPackageManager();
-        List<ApplicationInfo> applicationInfo = manager.getInstalledApplications(manager.GET_META_DATA|manager.GET_UNINSTALLED_PACKAGES);
+        List<ApplicationInfo> applicationInfo = manager.getInstalledApplications(manager.GET_META_DATA);
         for (int i = 0; i < applicationInfo.size(); i++){
             ApplicationInfo appInfo = applicationInfo.get(i);
             if (app.getName().contains(appInfo.processName)){

--- a/headless_launcher/build.gradle
+++ b/headless_launcher/build.gradle
@@ -27,8 +27,14 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 5
-    versionName "1.4.0"
+    versionCode 6
+    versionName "1.4.1"
+  }
+
+  productFlavors {
+    indigo {
+      applicationId "com.github.rosjava.android_remocons.headless_launcher.indigo"
+    }
   }
 
 }

--- a/listener/build.gradle
+++ b/listener/build.gradle
@@ -30,11 +30,14 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 1
-    versionName "1.0"
+    versionCode 2
+    versionName "1.0.1"
   }
-
+  productFlavors {
+    indigo {
+      applicationId "com.github.rosjava.android_remocons.listener.indigo"
+    }
+  }
 }
 
 defaultTasks 'assembleRelease'
- 

--- a/rocon_nfc_writer/build.gradle
+++ b/rocon_nfc_writer/build.gradle
@@ -28,8 +28,13 @@ android {
   defaultConfig {
     minSdkVersion 18
     targetSdkVersion 18
-    versionCode 1
-    versionName "1.0"
+    versionCode 2
+    versionName "1.0.1"
+  }
+  productFlavors {
+    indigo {
+      applicationId "com.github.rosjava.android_remocons.rocon_nfc_writer.indigo"
+    }
   }
 }
 

--- a/rocon_remocon/build.gradle
+++ b/rocon_remocon/build.gradle
@@ -48,8 +48,8 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 3
-    versionName "1.1.2"
+    versionCode 4
+    versionName "1.2.0"
   }
   productFlavors {
     indigo {

--- a/rocon_remocon/build.gradle
+++ b/rocon_remocon/build.gradle
@@ -48,8 +48,13 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 2
-    versionName "1.1"
+    versionCode 3
+    versionName "1.1.2"
+  }
+  productFlavors {
+    indigo {
+      applicationId "com.github.rosjava.android_remocons.rocon_remocon.indigo"
+    }
   }
 
 }

--- a/rocon_remocon/build.gradle
+++ b/rocon_remocon/build.gradle
@@ -48,8 +48,8 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 4
-    versionName "1.2.0"
+    versionCode 5
+    versionName "1.2.1"
   }
   productFlavors {
     indigo {

--- a/rocon_remocon/src/main/java/com/github/rosjava/android_remocons/rocon_remocon/Remocon.java
+++ b/rocon_remocon/src/main/java/com/github/rosjava/android_remocons/rocon_remocon/Remocon.java
@@ -157,15 +157,22 @@ public class Remocon extends RosActivity {
     protected void onStart() {
         super.onResume();
         if ( getIntent().getExtras() != null ) {
+            Log.i("Remocon", "onStart: " + Constants.ACTIVITY_SWITCHER_ID + "." + InteractionMode.CONCERT + "_app_name");
             concertAppName = getIntent().getStringExtra(Constants.ACTIVITY_SWITCHER_ID + "." + InteractionMode.CONCERT + "_app_name");
-            if (concertAppName.equals("AppChooser")) { // TODO ugly legacy identifier, it's misleading so change it sometime
-                Log.i("Remocon", "got intent from a closing remocon application");
-                statusPublisher.update(false, 0, null);
-                fromApplication = true;
+            if (concertAppName == null){
+                fromApplication = false;
+                fromApplication = false;
             }
-            else if (concertAppName.equals("NfcLauncher")) {
-                Log.i("Remocon", "got intent from an Nfc launched application");
-                fromNfcLauncher = true;
+            else{
+                if (concertAppName.equals("AppChooser")) { // TODO ugly legacy identifier, it's misleading so change it sometime
+                    Log.i("Remocon", "got intent from a closing remocon application");
+                    statusPublisher.update(false, 0, null);
+                    fromApplication = true;
+                }
+                else if (concertAppName.equals("NfcLauncher")) {
+                    Log.i("Remocon", "got intent from an Nfc launched application");
+                    fromNfcLauncher = true;
+                }
             }
         }
         super.onStart();

--- a/rocon_remocon/src/main/java/com/github/rosjava/android_remocons/rocon_remocon/Remocon.java
+++ b/rocon_remocon/src/main/java/com/github/rosjava/android_remocons/rocon_remocon/Remocon.java
@@ -264,7 +264,7 @@ public class Remocon extends RosActivity {
                                 // TODO try to no finish so statusPublisher remains while on app;  risky, but seems to work!    finish();
                             }
                             else if (result == AppLauncher.Result.NOTHING){
-                                statusPublisher.update(false, selectedInteraction.getHash(), selectedInteraction.getName());
+                                //statusPublisher.update(false, selectedInteraction.getHash(), selectedInteraction.getName());
                             }
                             else if (result == AppLauncher.Result.NOT_INSTALLED) {
                                // App not installed; ask for going to play store to download the missing app

--- a/talker/build.gradle
+++ b/talker/build.gradle
@@ -48,10 +48,14 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 15
-    versionCode 1
-    versionName "1.0"
+    versionCode 2
+    versionName "1.0.1"
   }
-
+  productFlavors {
+    indigo {
+      applicationId "com.github.rosjava.android_remocons.talker.indigo"
+    }
+  }
 }
 
 defaultTasks 'assembleRelease'


### PR DESCRIPTION
- Apply flavor to build as ros version and update version.
- Solve issues.
  - https://github.com/robotics-in-concert/android_remocons/issues/17
  - https://github.com/robotics-in-concert/android_remocons/issues/16
- Add app launch way for update naming android application package with ros version.
  - We generated and registered apks with application id included ros version for distinguishing previous version Listener. For example, Listener has application id like `com.github.rosjava.android_remocons.listener.indigo`.  
    However, when user try to launch Listener by remocon, remocon can not find the Listener app. This is because that remocon use package name for launching app, not application id. 
